### PR TITLE
Resolve colab compatibility issues in AppendixIII

### DIFF
--- a/AppendixIII/OpenAI_GPT_2.ipynb
+++ b/AppendixIII/OpenAI_GPT_2.ipynb
@@ -131,24 +131,27 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "3ce71c60-6217-48d1-c575-34992e9fa5c2"
+        "outputId": "6ee7c8d4-2387-467d-8c7d-2ab3b1ca695b"
       },
       "source": [
         "#@title Step 2: Cloning the OpenAI GPT-2 Repository \n",
-        "!git clone https://github.com/openai/gpt-2.git"
+        "#!git clone https://github.com/openai/gpt-2.git\n",
+        "!git clone https://github.com/nshepperd/gpt-2"
       ],
-      "execution_count": null,
+      "execution_count": 1,
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "Cloning into 'gpt-2'...\n",
-            "remote: Enumerating objects: 233, done.\u001b[K\n",
-            "remote: Total 233 (delta 0), reused 0 (delta 0), pack-reused 233\u001b[K\n",
-            "Receiving objects: 100% (233/233), 4.38 MiB | 12.25 MiB/s, done.\n",
-            "Resolving deltas: 100% (124/124), done.\n"
-          ],
-          "name": "stdout"
+            "remote: Enumerating objects: 429, done.\u001b[K\n",
+            "remote: Counting objects: 100% (138/138), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (127/127), done.\u001b[K\n",
+            "remote: Total 429 (delta 20), reused 77 (delta 11), pack-reused 291\u001b[K\n",
+            "Receiving objects: 100% (429/429), 4.47 MiB | 5.40 MiB/s, done.\n",
+            "Resolving deltas: 100% (216/216), done.\n"
+          ]
         }
       ]
     },
@@ -232,7 +235,7 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "238b6558-9d73-40a1-b42c-59deb6d0b196"
+        "outputId": "38b1b43f-c5df-4441-d3e8-085998e8d1e0"
       },
       "source": [
         "#@title Step 3: Installing the requirements\n",
@@ -240,59 +243,82 @@
         "os.chdir(\"/content/gpt-2\")    \n",
         "!pip3 install -r requirements.txt"
       ],
-      "execution_count": null,
+      "execution_count": 2,
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stdout",
           "text": [
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
             "Collecting fire>=0.1.3\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/11/07/a119a1aa04d37bc819940d95ed7e135a7dcca1c098123a3764a6dcace9e7/fire-0.4.0.tar.gz (87kB)\n",
-            "\u001b[K     |████████████████████████████████| 92kB 6.2MB/s \n",
-            "\u001b[?25hCollecting regex==2017.4.5\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/36/62/c0c0d762ffd4ffaf39f372eb8561b8d491a11ace5a7884610424a8b40f95/regex-2017.04.05.tar.gz (601kB)\n",
-            "\u001b[K     |████████████████████████████████| 604kB 13.4MB/s \n",
-            "\u001b[?25hCollecting requests==2.21.0\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/7d/e3/20f3d364d6c8e5d2353c72a67778eb189176f08e873c9900e10c0287b84b/requests-2.21.0-py2.py3-none-any.whl (57kB)\n",
-            "\u001b[K     |████████████████████████████████| 61kB 6.9MB/s \n",
+            "  Downloading fire-0.5.0.tar.gz (88 kB)\n",
+            "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/88.3 KB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m88.3/88.3 KB\u001b[0m \u001b[31m3.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "Collecting regex==2017.4.5\n",
+            "  Downloading regex-2017.04.05.tar.gz (601 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m601.6/601.6 KB\u001b[0m \u001b[31m15.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "Collecting requests==2.21.0\n",
+            "  Downloading requests-2.21.0-py2.py3-none-any.whl (57 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m58.0/58.0 KB\u001b[0m \u001b[31m5.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
             "\u001b[?25hCollecting tqdm==4.31.1\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/6c/4b/c38b5144cf167c4f52288517436ccafefe9dc01b8d1c190e18a6b154cd4a/tqdm-4.31.1-py2.py3-none-any.whl (48kB)\n",
-            "\u001b[K     |████████████████████████████████| 51kB 5.6MB/s \n",
-            "\u001b[?25hRequirement already satisfied: six in /usr/local/lib/python3.7/dist-packages (from fire>=0.1.3->-r requirements.txt (line 1)) (1.15.0)\n",
-            "Requirement already satisfied: termcolor in /usr/local/lib/python3.7/dist-packages (from fire>=0.1.3->-r requirements.txt (line 1)) (1.1.0)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests==2.21.0->-r requirements.txt (line 3)) (2021.5.30)\n",
-            "Collecting idna<2.9,>=2.5\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl (58kB)\n",
-            "\u001b[K     |████████████████████████████████| 61kB 7.5MB/s \n",
-            "\u001b[?25hRequirement already satisfied: urllib3<1.25,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests==2.21.0->-r requirements.txt (line 3)) (1.24.3)\n",
-            "Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /usr/local/lib/python3.7/dist-packages (from requests==2.21.0->-r requirements.txt (line 3)) (3.0.4)\n",
-            "Building wheels for collected packages: fire, regex\n",
-            "  Building wheel for fire (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for fire: filename=fire-0.4.0-py2.py3-none-any.whl size=115943 sha256=9b8cd96fb78bc8bc741c1ba90bcfa8f52381e1c25e5ad8bb58ed6a30967e51f6\n",
-            "  Stored in directory: /root/.cache/pip/wheels/af/19/30/1ea0cad502dcb4e66ed5a690279628c827aea38bbbab75d5ed\n",
+            "  Downloading tqdm-4.31.1-py2.py3-none-any.whl (48 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m48.3/48.3 KB\u001b[0m \u001b[31m5.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hCollecting toposort==1.5\n",
+            "  Downloading toposort-1.5-py2.py3-none-any.whl (7.6 kB)\n",
+            "Collecting chardet<3.1.0,>=3.0.2\n",
+            "  Downloading chardet-3.0.4-py2.py3-none-any.whl (133 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m133.4/133.4 KB\u001b[0m \u001b[31m11.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hCollecting urllib3<1.25,>=1.21.1\n",
+            "  Downloading urllib3-1.24.3-py2.py3-none-any.whl (118 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m118.8/118.8 KB\u001b[0m \u001b[31m16.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hCollecting idna<2.9,>=2.5\n",
+            "  Downloading idna-2.8-py2.py3-none-any.whl (58 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m58.6/58.6 KB\u001b[0m \u001b[31m7.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.9/dist-packages (from requests==2.21.0->-r requirements.txt (line 3)) (2022.12.7)\n",
+            "Requirement already satisfied: six in /usr/local/lib/python3.9/dist-packages (from fire>=0.1.3->-r requirements.txt (line 1)) (1.15.0)\n",
+            "Requirement already satisfied: termcolor in /usr/local/lib/python3.9/dist-packages (from fire>=0.1.3->-r requirements.txt (line 1)) (2.2.0)\n",
+            "Building wheels for collected packages: regex, fire\n",
             "  Building wheel for regex (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for regex: filename=regex-2017.4.5-cp37-cp37m-linux_x86_64.whl size=534388 sha256=0179b2ca2a05b094eda38db96ad802be0a19b4a36483e53e65deb0690c134ad7\n",
-            "  Stored in directory: /root/.cache/pip/wheels/75/07/38/3c16b529d50cb4e0cd3dbc7b75cece8a09c132692c74450b01\n",
-            "Successfully built fire regex\n",
-            "\u001b[31mERROR: spacy 2.2.4 has requirement tqdm<5.0.0,>=4.38.0, but you'll have tqdm 4.31.1 which is incompatible.\u001b[0m\n",
-            "\u001b[31mERROR: google-colab 1.0.0 has requirement requests~=2.23.0, but you'll have requests 2.21.0 which is incompatible.\u001b[0m\n",
-            "\u001b[31mERROR: fbprophet 0.7.1 has requirement tqdm>=4.36.1, but you'll have tqdm 4.31.1 which is incompatible.\u001b[0m\n",
-            "\u001b[31mERROR: datascience 0.10.6 has requirement folium==0.2.1, but you'll have folium 0.8.3 which is incompatible.\u001b[0m\n",
-            "Installing collected packages: fire, regex, idna, requests, tqdm\n",
-            "  Found existing installation: regex 2019.12.20\n",
-            "    Uninstalling regex-2019.12.20:\n",
-            "      Successfully uninstalled regex-2019.12.20\n",
-            "  Found existing installation: idna 2.10\n",
+            "  Created wheel for regex: filename=regex-2017.4.5-cp39-cp39-linux_x86_64.whl size=677639 sha256=74519aca350fdb85c3e9ced2ddf7a25dd6cd1d3ceb8bcab3d25a3f5c9073488c\n",
+            "  Stored in directory: /root/.cache/pip/wheels/d4/70/3e/734b51125cb2502e07f14b79b8aa2f06ade3dcee9d0e9c79cc\n",
+            "  Building wheel for fire (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for fire: filename=fire-0.5.0-py2.py3-none-any.whl size=116949 sha256=c2da40f9565cdbd5a7eee23780b4774a40e90868da75480d337f5842b7f4fc1e\n",
+            "  Stored in directory: /root/.cache/pip/wheels/f7/f1/89/b9ea2bf8f80ec027a88fef1d354b3816b4d3d29530988972f6\n",
+            "Successfully built regex fire\n",
+            "Installing collected packages: toposort, regex, chardet, urllib3, tqdm, idna, fire, requests\n",
+            "  Attempting uninstall: regex\n",
+            "    Found existing installation: regex 2022.6.2\n",
+            "    Uninstalling regex-2022.6.2:\n",
+            "      Successfully uninstalled regex-2022.6.2\n",
+            "  Attempting uninstall: chardet\n",
+            "    Found existing installation: chardet 4.0.0\n",
+            "    Uninstalling chardet-4.0.0:\n",
+            "      Successfully uninstalled chardet-4.0.0\n",
+            "  Attempting uninstall: urllib3\n",
+            "    Found existing installation: urllib3 1.26.14\n",
+            "    Uninstalling urllib3-1.26.14:\n",
+            "      Successfully uninstalled urllib3-1.26.14\n",
+            "  Attempting uninstall: tqdm\n",
+            "    Found existing installation: tqdm 4.65.0\n",
+            "    Uninstalling tqdm-4.65.0:\n",
+            "      Successfully uninstalled tqdm-4.65.0\n",
+            "  Attempting uninstall: idna\n",
+            "    Found existing installation: idna 2.10\n",
             "    Uninstalling idna-2.10:\n",
             "      Successfully uninstalled idna-2.10\n",
-            "  Found existing installation: requests 2.23.0\n",
-            "    Uninstalling requests-2.23.0:\n",
-            "      Successfully uninstalled requests-2.23.0\n",
-            "  Found existing installation: tqdm 4.41.1\n",
-            "    Uninstalling tqdm-4.41.1:\n",
-            "      Successfully uninstalled tqdm-4.41.1\n",
-            "Successfully installed fire-0.4.0 idna-2.8 regex-2017.4.5 requests-2.21.0 tqdm-4.31.1\n"
-          ],
-          "name": "stdout"
+            "  Attempting uninstall: requests\n",
+            "    Found existing installation: requests 2.25.1\n",
+            "    Uninstalling requests-2.25.1:\n",
+            "      Successfully uninstalled requests-2.25.1\n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "spacy 3.4.4 requires tqdm<5.0.0,>=4.38.0, but you have tqdm 4.31.1 which is incompatible.\n",
+            "prophet 1.1.2 requires tqdm>=4.36.1, but you have tqdm 4.31.1 which is incompatible.\n",
+            "panel 0.14.4 requires tqdm>=4.48.0, but you have tqdm 4.31.1 which is incompatible.\n",
+            "nltk 3.7 requires regex>=2021.8.3, but you have regex 2017.4.5 which is incompatible.\n",
+            "google-colab 1.0.0 requires requests>=2.25.1, but you have requests 2.21.0 which is incompatible.\u001b[0m\u001b[31m\n",
+            "\u001b[0mSuccessfully installed chardet-3.0.4 fire-0.5.0 idna-2.8 regex-2017.4.5 requests-2.21.0 toposort-1.5 tqdm-4.31.1 urllib3-1.24.3\n"
+          ]
         }
       ]
     },
@@ -312,25 +338,22 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "3b0c2619-9fba-4c5b-b1bf-df5dc67506c9"
+        "outputId": "5e77703f-770f-42c2-ac66-d6a9174a4e83"
       },
       "source": [
         "#@title Step 4 Checking the Version of TensorFlow \n",
-        "#Colab has tf 1.x and tf 2.x installed\n",
-        "#Restart runtime using 'Runtime' -> 'Restart runtime...'\n",
-        "%tensorflow_version 1.x\n",
+        "#Colab has tf 2.x installed. \n",
         "import tensorflow as tf\n",
         "print(tf.__version__)"
       ],
-      "execution_count": null,
+      "execution_count": 9,
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stdout",
           "text": [
-            "TensorFlow 1.x selected.\n",
-            "1.15.2\n"
-          ],
-          "name": "stdout"
+            "2.11.0\n"
+          ]
         }
       ]
     },
@@ -350,7 +373,7 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "c2882db6-fe57-4778-b4a1-18e22049c8d7"
+        "outputId": "d0b4efc4-b85a-461f-8d23-dbb9e7bda6df"
       },
       "source": [
         "#@title Step 5: Downloading the 345M parameter GPT-2 Model\n",
@@ -359,20 +382,20 @@
         "os.chdir(\"/content/gpt-2\")\n",
         "!python3 download_model.py '345M' "
       ],
-      "execution_count": null,
+      "execution_count": 4,
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stdout",
           "text": [
-            "Fetching checkpoint: 1.00kit [00:00, 755kit/s]                                                      \n",
-            "Fetching encoder.json: 1.04Mit [00:00, 1.46Mit/s]                                                   \n",
-            "Fetching hparams.json: 1.00kit [00:00, 723kit/s]                                                    \n",
-            "Fetching model.ckpt.data-00000-of-00001: 1.42Git [07:22, 3.20Mit/s]                                 \n",
-            "Fetching model.ckpt.index: 11.0kit [00:00, 7.53Mit/s]                                               \n",
-            "Fetching model.ckpt.meta: 927kit [00:00, 1.46Mit/s]                                                 \n",
-            "Fetching vocab.bpe: 457kit [00:00, 890kit/s]                                                        \n"
-          ],
-          "name": "stdout"
+            "Fetching checkpoint: 1.00kit [00:00, 930kit/s]                                                      \n",
+            "Fetching encoder.json: 1.04Mit [00:00, 5.68Mit/s]                                                   \n",
+            "Fetching hparams.json: 1.00kit [00:00, 905kit/s]                                                    \n",
+            "Fetching model.ckpt.data-00000-of-00001: 1.42Git [01:10, 20.3Mit/s]                                 \n",
+            "Fetching model.ckpt.index: 11.0kit [00:00, 6.41Mit/s]                                               \n",
+            "Fetching model.ckpt.meta: 927kit [00:00, 5.01Mit/s]                                                 \n",
+            "Fetching vocab.bpe: 457kit [00:00, 2.95Mit/s]                                                       \n"
+          ]
         }
       ]
     },
@@ -426,7 +449,7 @@
         "#@title Step 6: Printing UTF encoded text to the console\n",
         "!export PYTHONIOENCODING=UTF-8"
       ],
-      "execution_count": null,
+      "execution_count": 5,
       "outputs": []
     },
     {
@@ -439,7 +462,7 @@
         "import os # import after runtime is restarted\n",
         "os.chdir(\"/content/gpt-2/src\")"
       ],
-      "execution_count": null,
+      "execution_count": 6,
       "outputs": []
     },
     {
@@ -451,12 +474,13 @@
         "#@title Step 7a: Interactive Conditional Samples (src)\n",
         "#Project Source Code for Interactive Conditional Samples:\n",
         "# /content/gpt-2/src/interactive_conditional_samples.py file \n",
+        "# import tensorflow.compat.v1 for compatibility.\n",
         "import json\n",
         "import os\n",
         "import numpy as np\n",
-        "import tensorflow as tf"
+        "import tensorflow.compat.v1 as tf"
       ],
-      "execution_count": null,
+      "execution_count": 14,
       "outputs": []
     },
     {
@@ -480,7 +504,7 @@
         "#ModuleNotFoundError: No module named 'tensorflow.contrib'\n",
         "#then go back and run Step 2 Checking TensorFlow version "
       ],
-      "execution_count": null,
+      "execution_count": 15,
       "outputs": []
     },
     {
@@ -548,7 +572,7 @@
         "                    print(text)\n",
         "            print(\"=\" * 80)"
       ],
-      "execution_count": null,
+      "execution_count": 16,
       "outputs": []
     },
     {
@@ -566,153 +590,50 @@
         "id": "P8Prbrs-UHu3",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 1000
+          "height": 549
         },
-        "outputId": "8152308f-05f0-4c67-d857-9d2789a2f4be"
+        "outputId": "a2afb994-05cf-445b-bbf2-3a2b122f7421"
       },
       "source": [
         "#@title Step 9: Interacting with GPT-2 \n",
         "interact_model('345M',None,1,1,300,1,0,'/content/gpt-2/models')"
       ],
-      "execution_count": null,
+      "execution_count": 17,
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stderr",
           "text": [
-            "WARNING:tensorflow:From /content/gpt-2/src/sample.py:51: The name tf.AUTO_REUSE is deprecated. Please use tf.compat.v1.AUTO_REUSE instead.\n",
-            "\n",
-            "WARNING:tensorflow:From /content/gpt-2/src/model.py:148: The name tf.variable_scope is deprecated. Please use tf.compat.v1.variable_scope instead.\n",
-            "\n",
-            "WARNING:tensorflow:From /content/gpt-2/src/model.py:152: The name tf.get_variable is deprecated. Please use tf.compat.v1.get_variable instead.\n",
-            "\n",
-            "WARNING:tensorflow:From /content/gpt-2/src/model.py:36: The name tf.rsqrt is deprecated. Please use tf.math.rsqrt instead.\n",
-            "\n",
-            "WARNING:tensorflow:From /content/gpt-2/src/sample.py:64: to_float (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
+            "WARNING:tensorflow:From /usr/local/lib/python3.9/dist-packages/tensorflow/python/util/dispatch.py:1176: to_float (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
             "Instructions for updating:\n",
             "Use `tf.cast` instead.\n",
-            "WARNING:tensorflow:From /content/gpt-2/src/sample.py:39: where (from tensorflow.python.ops.array_ops) is deprecated and will be removed in a future version.\n",
+            "WARNING:tensorflow:From /usr/local/lib/python3.9/dist-packages/tensorflow/python/util/dispatch.py:1176: multinomial (from tensorflow.python.ops.random_ops) is deprecated and will be removed in a future version.\n",
             "Instructions for updating:\n",
-            "Use tf.where in 2.0, which has the same broadcast rule as np.where\n",
-            "WARNING:tensorflow:From /content/gpt-2/src/sample.py:67: multinomial (from tensorflow.python.ops.random_ops) is deprecated and will be removed in a future version.\n",
-            "Instructions for updating:\n",
-            "Use `tf.random.categorical` instead.\n",
-            "INFO:tensorflow:Restoring parameters from /content/gpt-2/models/345M/model.ckpt\n",
+            "Use `tf.random.categorical` instead.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
             "Model prompt >>> Human reason, in one sphere of its cognition, is called upon to consider questions, which it cannot decline, as they are presented by its own nature, but which it cannot answer, as they transcend every faculty of the mind.\n",
             "======================================== SAMPLE 1 ========================================\n",
-            " But to set religion back under that cursed vale of tears is naturally to hinder its penetrating into itself. For either the truth of the union of man and man is able to be touched under the feet of the naked self, or else that union is brought to the p161 light by blindness, havying no use; both of these must be admitted. In refusing to confess that the flesh gave history, which there is no word or word only can tell, required and revealed instead or adjuncts of powers or connections amongst the cerebral images, and in denying that saws or axes assemble neatly produced objects, tells me more too that will foster it. In the testimony of ancient writers (Aurora Juvenal, III, Claudius Scribonius, Seneca), spiritual powers that remained hidden before accorded with justice, privately placed themselves beneath attestation of justice, and since whose presence is easily detected when they belong to the subject for whom it was intended, have proved defective. Whether it be Socrates, who, being turned into the anthesis of Alcibiades, durst have himself become antisthetical? with Euthydemus, Adibezus, Herodotus, Cleopas, Seneca, or whoever sets aside his enlightening parentage to bear testimony to the prudence of conscience? is what undoubtedly happens. The physical brotherhood of provinces in time never collapsed to mean men; but they destroyed all ideas on which passion might rule. The biggest strain\n",
+            " Every truth released from matter, and presented to the recognition of its own nature; or, more correct and clearer, explained in the understanding, as delineated in its knowledge of itself: science by its power alone, delivers from the imago moralis irrational of its intelligence will to teach an acceptable doctrine in man's mind; not only fix and reality impose on it, but repress, nutrition and Amendment Ham� embodies a trend towards the distribution of learning : the devices I trust the progress toward can, and test our vision in Divine Knowledge. Learning takes place in all parts of us; self learned being the first to go to Babylon ; but, on the other hand, who knows where has been thrown the knowledge by diverse altitudes of human generation ? Progress then is inevitable. Our human faculties rise to a knowledge of their own, as a part of their mutual recreation, one above another. 60. Hence Instructionaries/ DAıgtadaŞi survey program of Pathilly exec- uite Towards Fear painting perhaps the millennial milestone excited total awareness confidence in intellect in a Britain abroad pre-eminently developed, influences sequestered noble career disintegrate in weaker fruits piloted ever free and inner based ?But ethereally Bela_kadaŞ, dreading thus Japan tlie fated consciousness, bar all effort to innovate markedly proves an SSLossible Sense-change caused by Capri observed by future nerves be of conveir Marco Coronel drop control was not Limits specializing Santiago\n",
             "================================================================================\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "ERROR:root:Internal Python error in the inspect module.\n",
-            "Below is the traceback from this internal error.\n",
-            "\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "Traceback (most recent call last):\n",
-            "  File \"/usr/local/lib/python3.7/dist-packages/ipykernel/kernelbase.py\", line 729, in _input_request\n",
-            "    ident, reply = self.session.recv(self.stdin_socket, 0)\n",
-            "  File \"/usr/local/lib/python3.7/dist-packages/jupyter_client/session.py\", line 803, in recv\n",
-            "    msg_list = socket.recv_multipart(mode, copy=copy)\n",
-            "  File \"/usr/local/lib/python3.7/dist-packages/zmq/sugar/socket.py\", line 583, in recv_multipart\n",
-            "    parts = [self.recv(flags, copy=copy, track=track)]\n",
-            "  File \"zmq/backend/cython/socket.pyx\", line 781, in zmq.backend.cython.socket.Socket.recv\n",
-            "  File \"zmq/backend/cython/socket.pyx\", line 817, in zmq.backend.cython.socket.Socket.recv\n",
-            "  File \"zmq/backend/cython/socket.pyx\", line 186, in zmq.backend.cython.socket._recv_copy\n",
-            "  File \"zmq/backend/cython/checkrc.pxd\", line 13, in zmq.backend.cython.checkrc._check_rc\n",
-            "KeyboardInterrupt\n",
-            "\n",
-            "During handling of the above exception, another exception occurred:\n",
-            "\n",
-            "Traceback (most recent call last):\n",
-            "  File \"/usr/local/lib/python3.7/dist-packages/IPython/core/interactiveshell.py\", line 2882, in run_code\n",
-            "    exec(code_obj, self.user_global_ns, self.user_ns)\n",
-            "  File \"<ipython-input-8-1a68aaa30b29>\", line 2, in <module>\n",
-            "    interact_model('345M',None,1,1,300,1,0,'/content/gpt-2/models')\n",
-            "  File \"<ipython-input-7-ad542f4b3966>\", line 43, in interact_model\n",
-            "    raw_text = input(\"Model prompt >>> \")\n",
-            "  File \"/usr/local/lib/python3.7/dist-packages/ipykernel/kernelbase.py\", line 704, in raw_input\n",
-            "    password=False,\n",
-            "  File \"/usr/local/lib/python3.7/dist-packages/ipykernel/kernelbase.py\", line 734, in _input_request\n",
-            "    raise KeyboardInterrupt\n",
-            "KeyboardInterrupt\n",
-            "\n",
-            "During handling of the above exception, another exception occurred:\n",
-            "\n",
-            "Traceback (most recent call last):\n",
-            "  File \"/usr/local/lib/python3.7/dist-packages/IPython/core/interactiveshell.py\", line 1823, in showtraceback\n",
-            "    stb = value._render_traceback_()\n",
-            "AttributeError: 'KeyboardInterrupt' object has no attribute '_render_traceback_'\n",
-            "\n",
-            "During handling of the above exception, another exception occurred:\n",
-            "\n",
-            "Traceback (most recent call last):\n",
-            "  File \"/usr/local/lib/python3.7/dist-packages/IPython/core/ultratb.py\", line 1132, in get_records\n",
-            "    return _fixed_getinnerframes(etb, number_of_lines_of_context, tb_offset)\n",
-            "  File \"/usr/local/lib/python3.7/dist-packages/IPython/core/ultratb.py\", line 313, in wrapped\n",
-            "    return f(*args, **kwargs)\n",
-            "  File \"/usr/local/lib/python3.7/dist-packages/IPython/core/ultratb.py\", line 358, in _fixed_getinnerframes\n",
-            "    records = fix_frame_records_filenames(inspect.getinnerframes(etb, context))\n",
-            "  File \"/usr/lib/python3.7/inspect.py\", line 1502, in getinnerframes\n",
-            "    frameinfo = (tb.tb_frame,) + getframeinfo(tb, context)\n",
-            "  File \"/usr/lib/python3.7/inspect.py\", line 1460, in getframeinfo\n",
-            "    filename = getsourcefile(frame) or getfile(frame)\n",
-            "  File \"/usr/lib/python3.7/inspect.py\", line 696, in getsourcefile\n",
-            "    if getattr(getmodule(object, filename), '__loader__', None) is not None:\n",
-            "  File \"/usr/lib/python3.7/inspect.py\", line 742, in getmodule\n",
-            "    os.path.realpath(f)] = module.__name__\n",
-            "  File \"/usr/lib/python3.7/posixpath.py\", line 395, in realpath\n",
-            "    path, ok = _joinrealpath(filename[:0], filename, {})\n",
-            "  File \"/usr/lib/python3.7/posixpath.py\", line 429, in _joinrealpath\n",
-            "    if not islink(newpath):\n",
-            "  File \"/usr/lib/python3.7/posixpath.py\", line 171, in islink\n",
-            "    st = os.lstat(path)\n",
-            "KeyboardInterrupt\n"
-          ],
-          "name": "stdout"
+          ]
         },
         {
           "output_type": "error",
-          "ename": "TypeError",
+          "ename": "KeyboardInterrupt",
           "evalue": "ignored",
           "traceback": [
             "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
             "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/ipykernel/kernelbase.py\u001b[0m in \u001b[0;36m_input_request\u001b[0;34m(self, prompt, ident, parent, password)\u001b[0m\n\u001b[1;32m    728\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 729\u001b[0;31m                 \u001b[0mident\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreply\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msession\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrecv\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstdin_socket\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    730\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/jupyter_client/session.py\u001b[0m in \u001b[0;36mrecv\u001b[0;34m(self, socket, mode, content, copy)\u001b[0m\n\u001b[1;32m    802\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 803\u001b[0;31m             \u001b[0mmsg_list\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msocket\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrecv_multipart\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcopy\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcopy\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    804\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mzmq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mZMQError\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/zmq/sugar/socket.py\u001b[0m in \u001b[0;36mrecv_multipart\u001b[0;34m(self, flags, copy, track)\u001b[0m\n\u001b[1;32m    582\u001b[0m         \"\"\"\n\u001b[0;32m--> 583\u001b[0;31m         \u001b[0mparts\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrecv\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mflags\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcopy\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcopy\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtrack\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtrack\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    584\u001b[0m         \u001b[0;31m# have first part already, only loop while more to receive\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32mzmq/backend/cython/socket.pyx\u001b[0m in \u001b[0;36mzmq.backend.cython.socket.Socket.recv\u001b[0;34m()\u001b[0m\n",
-            "\u001b[0;32mzmq/backend/cython/socket.pyx\u001b[0m in \u001b[0;36mzmq.backend.cython.socket.Socket.recv\u001b[0;34m()\u001b[0m\n",
-            "\u001b[0;32mzmq/backend/cython/socket.pyx\u001b[0m in \u001b[0;36mzmq.backend.cython.socket._recv_copy\u001b[0;34m()\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/zmq/backend/cython/checkrc.pxd\u001b[0m in \u001b[0;36mzmq.backend.cython.checkrc._check_rc\u001b[0;34m()\u001b[0m\n",
-            "\u001b[0;31mKeyboardInterrupt\u001b[0m: ",
-            "\nDuring handling of the above exception, another exception occurred:\n",
-            "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/IPython/core/interactiveshell.py\u001b[0m in \u001b[0;36mrun_code\u001b[0;34m(self, code_obj, result)\u001b[0m\n\u001b[1;32m   2881\u001b[0m                 \u001b[0;31m#rprint('Running code', repr(code_obj)) # dbg\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2882\u001b[0;31m                 \u001b[0mexec\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcode_obj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0muser_global_ns\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0muser_ns\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2883\u001b[0m             \u001b[0;32mfinally\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m<ipython-input-8-1a68aaa30b29>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m#@title Step 9: Interacting with GPT-2\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0minteract_model\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'345M'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m300\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m'/content/gpt-2/models'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-            "\u001b[0;32m<ipython-input-7-ad542f4b3966>\u001b[0m in \u001b[0;36minteract_model\u001b[0;34m(model_name, seed, nsamples, batch_size, length, temperature, top_k, models_dir)\u001b[0m\n\u001b[1;32m     42\u001b[0m         \u001b[0;32mwhile\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 43\u001b[0;31m             \u001b[0mraw_text\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0minput\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Model prompt >>> \"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     44\u001b[0m             \u001b[0;32mwhile\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mraw_text\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/ipykernel/kernelbase.py\u001b[0m in \u001b[0;36mraw_input\u001b[0;34m(self, prompt)\u001b[0m\n\u001b[1;32m    703\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_parent_header\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 704\u001b[0;31m             \u001b[0mpassword\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    705\u001b[0m         )\n",
-            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/ipykernel/kernelbase.py\u001b[0m in \u001b[0;36m_input_request\u001b[0;34m(self, prompt, ident, parent, password)\u001b[0m\n\u001b[1;32m    733\u001b[0m                 \u001b[0;31m# re-raise KeyboardInterrupt, to truncate traceback\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 734\u001b[0;31m                 \u001b[0;32mraise\u001b[0m \u001b[0mKeyboardInterrupt\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    735\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;31mKeyboardInterrupt\u001b[0m: ",
-            "\nDuring handling of the above exception, another exception occurred:\n",
-            "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/IPython/core/interactiveshell.py\u001b[0m in \u001b[0;36mshowtraceback\u001b[0;34m(self, exc_tuple, filename, tb_offset, exception_only)\u001b[0m\n\u001b[1;32m   1822\u001b[0m                         \u001b[0;31m# in the engines. This should return a list of strings.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1823\u001b[0;31m                         \u001b[0mstb\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_render_traceback_\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1824\u001b[0m                     \u001b[0;32mexcept\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;31mAttributeError\u001b[0m: 'KeyboardInterrupt' object has no attribute '_render_traceback_'",
-            "\nDuring handling of the above exception, another exception occurred:\n",
-            "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/IPython/core/interactiveshell.py\u001b[0m in \u001b[0;36mrun_code\u001b[0;34m(self, code_obj, result)\u001b[0m\n\u001b[1;32m   2897\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mresult\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2898\u001b[0m                 \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_in_exec\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msys\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexc_info\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2899\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshowtraceback\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2900\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2901\u001b[0m             \u001b[0moutflag\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/IPython/core/interactiveshell.py\u001b[0m in \u001b[0;36mshowtraceback\u001b[0;34m(self, exc_tuple, filename, tb_offset, exception_only)\u001b[0m\n\u001b[1;32m   1824\u001b[0m                     \u001b[0;32mexcept\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1825\u001b[0m                         stb = self.InteractiveTB.structured_traceback(etype,\n\u001b[0;32m-> 1826\u001b[0;31m                                             value, tb, tb_offset=tb_offset)\n\u001b[0m\u001b[1;32m   1827\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1828\u001b[0m                     \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_showtraceback\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0metype\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstb\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/IPython/core/ultratb.py\u001b[0m in \u001b[0;36mstructured_traceback\u001b[0;34m(self, etype, value, tb, tb_offset, number_of_lines_of_context)\u001b[0m\n\u001b[1;32m   1409\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtb\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtb\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1410\u001b[0m         return FormattedTB.structured_traceback(\n\u001b[0;32m-> 1411\u001b[0;31m             self, etype, value, tb, tb_offset, number_of_lines_of_context)\n\u001b[0m\u001b[1;32m   1412\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1413\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/IPython/core/ultratb.py\u001b[0m in \u001b[0;36mstructured_traceback\u001b[0;34m(self, etype, value, tb, tb_offset, number_of_lines_of_context)\u001b[0m\n\u001b[1;32m   1317\u001b[0m             \u001b[0;31m# Verbose modes need a full traceback\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1318\u001b[0m             return VerboseTB.structured_traceback(\n\u001b[0;32m-> 1319\u001b[0;31m                 \u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0metype\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtb\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtb_offset\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnumber_of_lines_of_context\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1320\u001b[0m             )\n\u001b[1;32m   1321\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/IPython/core/ultratb.py\u001b[0m in \u001b[0;36mstructured_traceback\u001b[0;34m(self, etype, evalue, etb, tb_offset, number_of_lines_of_context)\u001b[0m\n\u001b[1;32m   1180\u001b[0m             \u001b[0mexception\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_parts_of_chained_exception\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mevalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1181\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mexception\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1182\u001b[0;31m                 \u001b[0mformatted_exceptions\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprepare_chained_exception_message\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mevalue\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__cause__\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1183\u001b[0m                 \u001b[0metype\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mevalue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0metb\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mexception\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1184\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;31mTypeError\u001b[0m: can only concatenate str (not \"list\") to str"
+            "\u001b[0;32m<ipython-input-17-1a68aaa30b29>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m#@title Step 9: Interacting with GPT-2\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0minteract_model\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'345M'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m300\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m'/content/gpt-2/models'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+            "\u001b[0;32m<ipython-input-16-ad542f4b3966>\u001b[0m in \u001b[0;36minteract_model\u001b[0;34m(model_name, seed, nsamples, batch_size, length, temperature, top_k, models_dir)\u001b[0m\n\u001b[1;32m     41\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     42\u001b[0m         \u001b[0;32mwhile\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 43\u001b[0;31m             \u001b[0mraw_text\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0minput\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Model prompt >>> \"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     44\u001b[0m             \u001b[0;32mwhile\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mraw_text\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     45\u001b[0m                 \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Prompt should not be empty!'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.9/dist-packages/ipykernel/kernelbase.py\u001b[0m in \u001b[0;36mraw_input\u001b[0;34m(self, prompt)\u001b[0m\n\u001b[1;32m    858\u001b[0m                 \u001b[0;34m\"raw_input was called, but this frontend does not support input requests.\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    859\u001b[0m             )\n\u001b[0;32m--> 860\u001b[0;31m         return self._input_request(str(prompt),\n\u001b[0m\u001b[1;32m    861\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_parent_ident\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    862\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_parent_header\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.9/dist-packages/ipykernel/kernelbase.py\u001b[0m in \u001b[0;36m_input_request\u001b[0;34m(self, prompt, ident, parent, password)\u001b[0m\n\u001b[1;32m    902\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mKeyboardInterrupt\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    903\u001b[0m                 \u001b[0;31m# re-raise KeyboardInterrupt, to truncate traceback\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 904\u001b[0;31m                 \u001b[0;32mraise\u001b[0m \u001b[0mKeyboardInterrupt\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Interrupted by user\"\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    905\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mException\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    906\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlog\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwarning\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Invalid Message:\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mexc_info\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;31mKeyboardInterrupt\u001b[0m: Interrupted by user"
           ]
         }
       ]


### PR DESCRIPTION
## Issue
As noted in [AppendixIII/OpenAI_GPT_2.ipynb](https://github.com/Denis2054/Transformers-for-NLP-2nd-Edition/blob/8d7dbebcd792cc29729a7bec0367e39736ec2951/AppendixIII/OpenAI_GPT_2.ipynb) ,  we cannot run notebook in Colab for they does not support Tensforflow 1.x anymore.

## Solution
To handle this, I changed source repository from `OpenAI` to `nshepperd`, and imported `tensorflow.compat.v1` for compatibility.

## Change Notes
-  in step 2, changed source repo from `!git clone https://github.com/openai/gpt-2.git` to  `!git clone https://github.com/nshepperd/gpt-2`
- in step 4, deleted line `%tensorflow_version 1.x` 
- in step 7a, imported `tensorflow.compat.v1` for compatibility

I did not changed the notes in preface. So please edit if changes are needed.